### PR TITLE
Advance to version 0.13 of Scope

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,9 +66,12 @@ scope:
   command:
     - "--probe.docker"
     - "true"
-  image: weaveworks/scope:0.11.1
+  image: weaveworks/scope:0.13.0
   net: "host"
   pid: "host"
   ports:
     - "4040:4040"
   privileged: true
+  tty: true
+  labels:
+    - "works.weave.role=system"


### PR DESCRIPTION
Version 0.13 of Scope differentiates node types using shapes and groups using stacked shapes.

There's also a high-contrast mode (handy for presentations on low res projectors), a lot of performance improvements and a few other handy features that'll be in the release announcement, shortly.

<img width="1013" alt="scope-0 13" src="https://cloud.githubusercontent.com/assets/303151/13401400/dd03904c-df03-11e5-9630-29b376d398cf.png">
